### PR TITLE
Add a gitignore for build artifacts and ephemeral junk (try 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 asm/**
 !asm/*.s
+!asm/*.inc
+!asm/Makefile
 
 # Generated at build time
 c2t.h

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+asm/**
+!asm/*.s
+
+# Generated at build time
+c2t.h
+
+# The contents of bin, apart from Windows, are just build
+# artifacts and could have been put there for any platform.
+# Let's not check those in.
+bin/**
+
+# Apparently these are distribution binaries for Windows
+# so if they're around we commit them.
+# TODO: use releases instead of this
+# TODO: make it so that "make clean" on non-Windows doesn't
+#       clobber the Windows binary and cause git to delete.
+!bin/*.exe
+
+# Annoying macOS Finder state detritus
+.DS_Store
+
+# Installed at build time, not a distributed artifact
+cc65*

--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,9 @@
 asm/**
 !asm/*.s
 !asm/*.inc
-!asm/Makefile
 
-# Generated at build time
-c2t.h
-
-# The contents of bin, apart from Windows, are just build
-# artifacts and could have been put there for any platform.
-# Let's not check those in.
-bin/**
-
-# Apparently these are distribution binaries for Windows
-# so if they're around we commit them.
-# TODO: use releases instead of this
-# TODO: make it so that "make clean" on non-Windows doesn't
-#       clobber the Windows binary and cause git to delete.
-!bin/*.exe
+# Generated at build time but being kept upstream
+# c2t.h
 
 # Annoying macOS Finder state detritus
 .DS_Store


### PR DESCRIPTION
We should .gitignore stuff that'll be build artifacts or ephemeral build components. Including c2t.h, which is generated code, and cc65 which is an external build dependency.

Oh, and non-source asm/. And some annoying macOS junk.

Try 2, now with proper cherrypick.