### PR TITLE
Minimalist .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+asm/**
+!asm/*.s
+!asm/*.inc
+
+# Generated at build time but being kept upstream
+# c2t.h
+
+# Annoying macOS Finder state detritus
+.DS_Store
+
+# Installed at build time, not a distributed artifact
+cc65*


### PR DESCRIPTION
This is the smallest .gitignore that makes sense: asm, cc65, and the macos crud.

Note that it still runs the risk of a sloppy commit clobbering the existing, stale `bin/c2t` and `bin/c2t-96h` for linux.  Since other platforms—aarc64-macos, amd64-macos, arm-linux/aarch64-linux on Pi or other SBCs—can and will build bins with the same name we can no longer commit from `make clean` because of them. These old bins need to be carefully worked around every time.

Personally I have the hardware to do any of those non-Windows builds I mentioned but not the Windows build. Because of that there's currently no way for me to pretend to be the CI here should we choose to keep bins in the repo in sync with the source even if no other platforms are added. They'll continue to get more and more stale.

I'd really, really like to ignore those two files if at all possible so that the stale files can exist in the upstream but are no longer added to the index. On the rare occasion someone wants to manually build the linux bin (I could do this if need be) and add it to the repo they could manually tweak their .gitignore, add the file again, and commit.

Having said that, the proposal to do so is **not** in 7a2c5f9. We could discuss all that in a separate PR context unless it makes sense to do it now.